### PR TITLE
Output version when `--version`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const gitBranch = require('git-branch')
 const rasper = require('rasper')
+const pkg = require('./package.json')
 const { exec } = require('child_process')
 
 const { error, log } = console
@@ -30,7 +31,7 @@ Examples:
 }
 
 if (options.version) {
-	log(`v${version}`)
+	log(`v${pkg.version}`)
 	exit(2)
 }
 


### PR DESCRIPTION
<!--
# Contributing

We would love for you to contribute and help us make this even better! Start reading [this document](contributing.md) to see it is not difficult as you might have imagined.

## Code of Conduct

Help us keep this project open and inclusive. Please read and follow our thoughts on [Code of Conduct](http://confcodeofconduct.com/).

## License

By contributing your code, you agree to license your contribution under the MIT license.
-->

### Checklist
- [ ] `npm start` and/or `npm test` it worked
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

### Description of change

A tiny fix that resolves `gitfit -v, --version` command.

The tests aren't passing but it seems to be a problem with [`cjpatoilo/eslint-config-styled`](https://github.com/cjpatoilo/eslint-config-styled) or its usage.

By running eslint with `--parser-options=ecmaVersion:8` we can see that everything is ok. 
