### PR TITLE
Add eslint "required" config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+	"extends": "styled"
+}


### PR DESCRIPTION
<!--
# Contributing

We would love for you to contribute and help us make this even better! Start reading [this document](contributing.md) to see it is not difficult as you might have imagined.

## Code of Conduct

Help us keep this project open and inclusive. Please read and follow our thoughts on [Code of Conduct](http://confcodeofconduct.com/).

## License

By contributing your code, you agree to license your contribution under the MIT license.
-->

### Checklist
- [x] `npm start` and/or `npm test` it worked
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

### Description of change
From #1 

> The tests aren't passing but it seems to be a problem with cjpatoilo/eslint-config-styled or its usage.

I don't know the real problem here, but looking at [`cjpatoilo/marshmallow`](https://github.com/cjpatoilo/marshmallow), a `.eslintrc` file is being used together with the `-c styled` in the command line. 

If you have a better approach to solve this problem, please let me know.
